### PR TITLE
Use VMSS client for Azure

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -25,7 +25,7 @@ var (
 )
 
 type Client struct {
-	VirtualMachineClient *compute.VirtualMachinesClient
+	VirtualMachineScaleSetsClient *compute.VirtualMachineScaleSetsClient
 }
 
 func NewClient() (*Client, error) {
@@ -67,10 +67,10 @@ func NewClient() (*Client, error) {
 			return nil, microerror.Mask(err)
 		}
 
-		virtualMachineClient := compute.NewVirtualMachinesClient(azureSubscriptionID)
-		virtualMachineClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
+		virtualMachineScaleSetsClient := compute.NewVirtualMachineScaleSetsClient(azureSubscriptionID)
+		virtualMachineScaleSetsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 
-		a.VirtualMachineClient = &virtualMachineClient
+		a.VirtualMachineScaleSetsClient = &virtualMachineScaleSetsClient
 	}
 
 	return a, nil


### PR DESCRIPTION
Towards giantswarm/giantswarm#3377

This is needed for rebooting the master node for the clusterstate e2e test. I added the Virtual Machine client but it has to be the Scale Sets client.