### PR TITLE
Pin dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -78,12 +78,12 @@
   version = "v3.2.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f7ae60209ba785a98a5b27ed43ec9778f74e6c7623b5ff3d86f900f66c86fac1"
+  digest = "1:701a5f5a7297ced0c7b9aeeba6a40ef47663b956d56e7acd09fe0d1c31eb1e4b"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3bc3cb1a36700aa4bbfcf6c335bc2ab92ad66d8d"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:8b4bb15de2e698d359eeec15c42453567c98972a70c8619946050360ec02ec32"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
   version = "=v40.0.0"
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 

--- a/vendor/github.com/giantswarm/microerror/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/microerror/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] 2020-02-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/microerror/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/microerror/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/microerror/DCO
+++ b/vendor/github.com/giantswarm/microerror/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/vendor/github.com/giantswarm/microerror/LICENSE
+++ b/vendor/github.com/giantswarm/microerror/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/giantswarm/microerror/README.md
+++ b/vendor/github.com/giantswarm/microerror/README.md
@@ -1,3 +1,6 @@
+[![godoc](https://img.shields.io/badge/godoc-reference-5272B4.svg)](https://godoc.org/github.com/giantswarm/microerror)
+[![CircleCI](https://circleci.com/gh/giantswarm/microerror.svg?style=shield&circle-token=f40c341b2c40c9aa5852fda592755a8f8aedc983)](https://circleci.com/gh/giantswarm/microerror)
+
 # microerror
 
 Go library to facilitate error handling, based on [juju/errgo](https://github.com/juju/errgo)

--- a/vendor/github.com/giantswarm/microerror/funcs.go
+++ b/vendor/github.com/giantswarm/microerror/funcs.go
@@ -1,0 +1,43 @@
+package microerror
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+// Stack prints the error with the stack if its argument is underlying
+// microerror error or result of Error function otherwise. Its main purpose is
+// to be used for a value for "stack" micrologger key.
+//
+// Example:
+//
+//	logger.LogCtx(ctx, "level", "error", "message", "failed to do a thing", "stack", microerror.Stack(err))
+//
+func Stack(err error) string {
+	switch err.(type) {
+	case nil:
+		return fmt.Sprintf("%v", nil)
+	case *errgo.Err:
+		return fmt.Sprintf("%#v", err)
+	default:
+		return err.Error()
+	}
+}
+
+// Desc returns the description of a microerror.Error.
+func Desc(err error) string {
+	c := Cause(err)
+	switch c.(type) {
+	case nil:
+		return ""
+	case *Error:
+		e, ok := c.(*Error)
+		if ok {
+			return e.Desc
+		}
+		return ""
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
We need to pin the microerror dependency to the v0.1.0 version to avoid getting breaking changes.

